### PR TITLE
fix: Use Route component instead of raw component for routes

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -19,7 +19,7 @@ import {
   extensionStatuses
 } from '../helpers/extensionStatus'
 
-const RedirectIfExtensionInstalled = ({ component: Component, ...props }) => {
+const RedirectIfExtensionInstalled = props => {
   const extensionInstalled = useExtensionStatus()
 
   if (extensionInstalled === extensionStatuses.checking) {
@@ -30,7 +30,7 @@ const RedirectIfExtensionInstalled = ({ component: Component, ...props }) => {
     return <Redirect to="/installation/installed" />
   }
 
-  return <Component {...props} />
+  return <Route {...props} />
 }
 
 export const DumbApp = ({ breakpoints: { isDesktop } }) => {


### PR DESCRIPTION
In https://github.com/cozy/cozy-passwords/pull/4, I used a
RedirectIfExtensionInstalled component the handle automatic redirection
to the last step if the extension is installed.

The problem was that this component directly rendered the component
passed to it instead of rendering a Route. Thus, the props passed to a
component rendered by a Route were not passed to the rendered component.
It resulted in HintPage not being passed `history` prop, on which it
relies to redirect to the next step when the hint has been successfuly
updated.