### PR TITLE
feat(HintPage): Bypass the step if a hint is already defined

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -26,9 +26,9 @@
       "verbs": ["GET"]
     },
     "settings": {
-      "description": "Required to update the password hint",
+      "description": "Required to check the existence of and update the password hint",
       "type": "io.cozy.settings",
-      "verbs": ["PUT"]
+      "verbs": ["GET", "PUT"]
     }
   }
 }

--- a/src/components/HintPage.jsx
+++ b/src/components/HintPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import Button from 'cozy-ui/transpiled/react/Button'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Input from 'cozy-ui/transpiled/react/Input'
@@ -10,11 +10,15 @@ import NarrowContent from 'cozy-ui/transpiled/react/NarrowContent'
 import passwordClueIcon from 'assets/password-clue.svg'
 import { MainTitle, Text } from 'cozy-ui/transpiled/react/Text'
 import Stack from 'cozy-ui/transpiled/react/Stack'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 const DumbHintPage = props => {
   const { t, client, history } = props
   const [hint, setHint] = useState('')
   const [saving, setSaving] = useState(false)
+  const [loading, setLoading] = useState(true)
+
+  const goToNextStep = () => history.push('/installation')
 
   const handleSubmit = async e => {
     e.preventDefault()
@@ -26,7 +30,7 @@ const DumbHintPage = props => {
         hint
       })
 
-      history.push('/installation')
+      goToNextStep()
     } catch (err) {
       Alerter.error(t('HintPage.error'))
 
@@ -35,6 +39,29 @@ const DumbHintPage = props => {
     } finally {
       setSaving(false)
     }
+  }
+
+  useEffect(() => {
+    const checkExistingHint = async () => {
+      try {
+        await client
+          .getStackClient()
+          .collection('io.cozy.settings')
+          .get('hint')
+
+        // If the user has already defined a hint, bypass this step
+        goToNextStep()
+      } catch (err) {
+        // In case of any error, the user should enter a hint
+        setLoading(false)
+      }
+    }
+
+    checkExistingHint()
+  }, [])
+
+  if (loading) {
+    return <Spinner size="xxlarge" middle={true} />
   }
 
   return (


### PR DESCRIPTION
When the user decides to keeps his current password and he has already
defined a hint, we skip the hint step.

The GET /settings/hint route has been added to the stack in https://github.com/cozy/cozy-stack/pull/2322