### PR TITLE
feat: Add extension-check-disabled flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "watch:mobile": "cs watch --mobile",
     "start": "cs start --hot --browser",
     "deploy": "git-directory-deploy --directory build/ --branch ${DEPLOY_BRANCH:-build} --repo=${DEPLOY_REPOSITORY:-https://$GITHUB_TOKEN@github.com/cozy/cozy-passwords.git}",
-    "test": "cs test --verbose --coverage",
+    "test": "cs test --verbose",
     "cozyPublish": "cozy-app-publish --token $REGISTRY_TOKEN --prepublish downcloud --space default"
   },
   "repository": {
@@ -45,8 +45,10 @@
   },
   "dependencies": {
     "@material-ui/core": "3",
+    "@testing-library/react-hooks": "^3.2.1",
     "cozy-bar": "7.12.2",
     "cozy-client": "8.5.1",
+    "cozy-flags": "2.2.0",
     "cozy-scripts": "2.0.2",
     "cozy-ui": "30.6.0",
     "detect-browser": "^4.8.0",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { hot } from 'react-hot-loader'
 import { Route, Switch, Redirect, HashRouter } from 'react-router-dom'
 import { Layout, Main, Content } from 'cozy-ui/transpiled/react/Layout'
@@ -18,6 +18,7 @@ import {
   useExtensionStatus,
   extensionStatuses
 } from '../helpers/extensionStatus'
+import flag, { FlagSwitcher } from 'cozy-flags'
 
 const RedirectIfExtensionInstalled = props => {
   const extensionInstalled = useExtensionStatus()
@@ -34,6 +35,12 @@ const RedirectIfExtensionInstalled = props => {
 }
 
 export const DumbApp = ({ breakpoints: { isDesktop } }) => {
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'development') {
+      flag('switcher', true)
+    }
+  }, [])
+
   if (isDesktop) {
     return (
       <MuiCozyTheme>
@@ -74,6 +81,7 @@ export const DumbApp = ({ breakpoints: { isDesktop } }) => {
             </Main>
             <IconSprite />
             <Alerter />
+            <FlagSwitcher />
           </Layout>
         </HashRouter>
       </MuiCozyTheme>

--- a/src/helpers/extensionStatus.js
+++ b/src/helpers/extensionStatus.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import get from 'lodash/get'
+import { useFlag } from 'cozy-flags'
 
 export const extensionStatuses = {
   checking: 'checking',
@@ -9,8 +10,13 @@ export const extensionStatuses = {
 
 export const useExtensionStatus = () => {
   const [installed, setInstalled] = useState(extensionStatuses.notInstalled)
+  const extensionCheckDisabled = useFlag('extension-check-disabled')
 
   useEffect(() => {
+    if (extensionCheckDisabled) {
+      return
+    }
+
     const checkExtensionInstallation = () => {
       window.postMessage(
         {
@@ -32,14 +38,17 @@ export const useExtensionStatus = () => {
       }
 
       setInstalled(extensionStatuses.installed)
+      cleanup()
     }
 
     window.addEventListener('message', handleInstalled)
 
-    return () => {
+    const cleanup = () => {
       clearInterval(interval)
       window.removeEventListener('message', handleInstalled)
     }
+
+    return cleanup
   }, [])
 
   return installed

--- a/src/helpers/extensionStatus.spec.js
+++ b/src/helpers/extensionStatus.spec.js
@@ -1,0 +1,59 @@
+import { useExtensionStatus, extensionStatuses } from './extensionStatus'
+import { renderHook, act } from '@testing-library/react-hooks'
+import { useFlag } from 'cozy-flags'
+
+jest.mock('cozy-flags')
+
+const sendMessageFromExtension = () => {
+  const event = new Event('message')
+  event.data = {
+    message: {
+      source: 'cozy-extension'
+    }
+  }
+
+  window.dispatchEvent(event)
+}
+
+describe('useExtensionStatus', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.spyOn(window, 'postMessage').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should send messages to the extension until it receives a message indicating that the extension is installed', () => {
+    const { result } = renderHook(() => useExtensionStatus())
+
+    expect(result.current).toBe(extensionStatuses.notInstalled)
+    expect(window.postMessage).toHaveBeenCalledTimes(1)
+
+    jest.advanceTimersByTime(1000)
+    expect(window.postMessage).toHaveBeenCalledTimes(2)
+
+    act(() => {
+      sendMessageFromExtension()
+    })
+
+    expect(result.current).toBe(extensionStatuses.installed)
+
+    jest.advanceTimersByTime(1000)
+    expect(window.postMessage).toHaveBeenCalledTimes(2)
+  })
+
+  describe('when the extension-check-disabled flag is enabled', () => {
+    beforeEach(() => {
+      useFlag.mockReturnValue(true)
+    })
+
+    it('should not send messages and tell the extension is not installed', () => {
+      const { result } = renderHook(() => useExtensionStatus())
+
+      expect(result.current).toBe(extensionStatuses.notInstalled)
+      expect(window.postMessage).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -882,6 +882,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.5.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
+  integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.0.0 <7.4.0":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
@@ -1271,6 +1278,14 @@
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
 
+"@testing-library/react-hooks@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.2.1.tgz#19b6caa048ef15faa69d439c469033873ea01294"
+  integrity sha512-1OB6Ksvlk6BCJA1xpj8/WWz0XVd1qRcgqdaFAq+xeC6l61Ucj0P6QpA5u+Db/x9gU4DCX8ziR5b66Mlfg0M2RA==
+  dependencies:
+    "@babel/runtime" "^7.5.4"
+    "@types/testing-library__react-hooks" "^3.0.0"
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -1366,6 +1381,13 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
+"@types/react-test-renderer@*":
+  version "16.9.2"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.2.tgz#e1c408831e8183e5ad748fdece02214a7c2ab6c5"
+  integrity sha512-4eJr1JFLIAlWhzDkBCkhrOIWOvOxcCAfQh+jiKg7l/nNZcCIL2MHl2dZhogIFKyHzedVWHaVP1Yydq/Ruu4agw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^2.0.8":
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.9.2.tgz#c48cf2a11977c8b4ff539a1c91d259eaa627028d"
@@ -1395,6 +1417,14 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
+
+"@types/testing-library__react-hooks@^3.0.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.2.0.tgz#52f3a109bef06080e3b1e3ae7ea1c014ce859897"
+  integrity sha512-dE8iMTuR5lzB+MqnxlzORlXzXyCL0EKfzH0w/lau20OpkHD37EaWjZDz0iNG8b71iEtxT4XKGmSKAGVEqk46mw==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-test-renderer" "*"
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -3189,6 +3219,13 @@ cozy-device-helper@1.8.0, cozy-device-helper@^1.7.3:
   integrity sha512-XomsjdCCWcS01x1QK/Wc4EI4zTxJN8Ouh7956wm2AEQyjj4lN+7cj8tqEBlb8fLWm68/3S3Z4V3iSJDgnJHu6A==
   dependencies:
     lodash "4.17.15"
+
+cozy-flags@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.2.0.tgz#5367b044cc43b738cf8db3791ad4812a472cb8c5"
+  integrity sha512-U0C0jDgMTHhFuKCKZOukEafsRnHhcditLShTjK0RE00mQjcVuqkPucF1CT5u5U/EXLtCi9yKQBdQrlk8bl9d0w==
+  dependencies:
+    microee "^0.0.6"
 
 cozy-interapp@0.4.9:
   version "0.4.9"


### PR DESCRIPTION
While developing, it's convenient to disable the automatic redirection
to last step if the browser extension is installed. When this flag is
enabled, the app doesn't check if the extension is installed, so we are
not redirected.