### PR TITLE
Use better namespaced events to check extension status

### DIFF
--- a/src/helpers/extensionStatus.js
+++ b/src/helpers/extensionStatus.js
@@ -19,7 +19,7 @@ export const useExtensionStatus = () => {
 
     const checkExtensionStatus = () => {
       const event = document.createEvent('Event')
-      event.initEvent('check-cozy-extension-status')
+      event.initEvent('cozy.passwordextension.check-status')
       document.dispatchEvent(event)
     }
 
@@ -34,12 +34,12 @@ export const useExtensionStatus = () => {
     }
 
     document.addEventListener(
-      'cozy-extension-installed',
+      'cozy.passwordextension.installed',
       handleExtensionInstalled
     )
 
     document.addEventListener(
-      'cozy-extension-connected',
+      'cozy.passwordextension.connected',
       handleExtensionConnected
     )
 

--- a/src/helpers/extensionStatus.js
+++ b/src/helpers/extensionStatus.js
@@ -8,6 +8,10 @@ export const extensionStatuses = {
   connected: 'connected'
 }
 
+/*
+ * See https://github.com/cozy/cozy-keys-browser/blob/master/docs/extension-status.md
+ * to learn more about how the extension can give us its current status
+ */
 export const useExtensionStatus = () => {
   const [status, setStatus] = useState(extensionStatuses.notInstalled)
   const extensionCheckDisabled = useFlag('extension-check-disabled')

--- a/src/helpers/extensionStatus.spec.js
+++ b/src/helpers/extensionStatus.spec.js
@@ -29,13 +29,13 @@ describe('useExtensionStatus', () => {
     expect(document.dispatchEvent).toHaveBeenCalledTimes(2)
 
     act(() => {
-      triggerExtensionEvent('cozy-extension-installed')
+      triggerExtensionEvent('cozy.passwordextension.installed')
     })
 
     expect(result.current).toBe(extensionStatuses.installed)
 
     act(() => {
-      triggerExtensionEvent('cozy-extension-connected')
+      triggerExtensionEvent('cozy.passwordextension.connected')
     })
 
     expect(result.current).toBe(extensionStatuses.connected)

--- a/src/helpers/extensionStatus.spec.js
+++ b/src/helpers/extensionStatus.spec.js
@@ -10,23 +10,34 @@ const triggerExtensionEvent = type => {
 }
 
 describe('useExtensionStatus', () => {
+  const handleExtensionStatusCheck = jest.fn()
+
   beforeEach(() => {
     jest.useFakeTimers()
-    jest.spyOn(document, 'dispatchEvent')
+
+    document.addEventListener(
+      'cozy.passwordextension.check-status',
+      handleExtensionStatusCheck
+    )
   })
 
   afterEach(() => {
     jest.resetAllMocks()
+
+    document.removeEventListener(
+      'cozy.passwordextension.check-status',
+      handleExtensionStatusCheck
+    )
   })
 
   it('should ask the extension to check its status', () => {
     const { result } = renderHook(() => useExtensionStatus())
 
     expect(result.current).toBe(extensionStatuses.notInstalled)
-    expect(document.dispatchEvent).toHaveBeenCalledTimes(1)
+    expect(handleExtensionStatusCheck).toHaveBeenCalledTimes(1)
 
     jest.advanceTimersByTime(1000)
-    expect(document.dispatchEvent).toHaveBeenCalledTimes(2)
+    expect(handleExtensionStatusCheck).toHaveBeenCalledTimes(2)
 
     act(() => {
       triggerExtensionEvent('cozy.passwordextension.installed')
@@ -50,7 +61,7 @@ describe('useExtensionStatus', () => {
       const { result } = renderHook(() => useExtensionStatus())
 
       expect(result.current).toBe(extensionStatuses.notInstalled)
-      expect(document.dispatchEvent).not.toHaveBeenCalled()
+      expect(handleExtensionStatusCheck).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
I merged https://github.com/cozy/cozy-passwords/pull/16 before seeing https://github.com/cozy/cozy-passwords/pull/16#discussion_r380160208, which was a good change request.

In this PR, I just use different custom event types to handle extension status checks. And I also enhance tests because they didn't make sure that the initial (`check-status`) event is sent.