### PR TITLE
chore: Mattermost message after publication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ before_install:
   - if [ "$TRAVIS_SECURE_ENV_VARS" != "false" ]; then eval "$(ssh-agent -s)"; fi
   - if [ "$TRAVIS_SECURE_ENV_VARS" != "false" ]; then chmod 600 id_rsa_downcloud_passwords; fi
   - if [ "$TRAVIS_SECURE_ENV_VARS" != "false" ]; then ssh-add id_rsa_downcloud_passwords; fi
+before_deploy:
+  - yarn add cozy-app-publish
 deploy:
   - provider: script
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,13 @@ branches:
   - /^\d+\.\d+\.\d+(\-beta.\d+)?$/
 env:
   global:
+    - MATTERMOST_CHANNEL: "{"dev":"feat---password-mgr","beta":"feat---password-mgr,publication","stable":"feat---password-mgr,publication"}"
     # GITHUB_TOKEN for yarn deploy script
     - secure: "HvogVX7tAwRIjrQ5/uw3viZgJUkkWZMpfqBk239wpuah+zjJpuuE07xvS0kgusWaJtDqS9vkd4zzu7YYemLPQu0bdkphj44QrJaF4mfqT5pN8SxSrkLD+P7cO6tHJixQlmx/nWczVTZSAgtz9CCjUCeyjC22B4CaOJ469kOuLN5JCOQRGl2S0nbBiQFDjJmkhC2P7YjAY/Xpkk8a0i3FftqD34L0lzRHfiEqQHYvtg87n6kHxW0+KXk2hc3sJbUasU1p2SfrZKUNL9SKJ0XVlLz8/Z87V/sfE8OCMfY5sdzF1L4J08Zk/CEVNflNVm3u4TkzGhL3AqzZDuhry7gcOB3ON8mJ/jq7BS6/MU/gF0N2tsseDCRaHHknn7HfPHvuO9oIRxBUCQ4knabEtSAZFwf4KPB8A+z/OmRaR+BbpEPLmM/xCqL4P+gUchizPO+eoPDXcclHoOrycpW6s13kfHiGPajVETiyc9A5Ao1ZMEjbOqP/3R0fS8/d9BTKY6VMAPKwRbza+E/bYSN1+hM9ocsHnoaCYLgWbDXqashPNHckVqltmROQaLOM19D/6VUiD+BmEplcIMSe+ekbv8BHVIYXPhe4g3mr0oe8oc/mUOAjwXlf2nn1L898IaFfnclMe+hv3WAF1BdASxyxurF7hkUUgKm2jFQfMhp4Ft19uc0="
     # REGISTRY_TOKEN for yarn cozyPublish script
     - secure: "FWpj8hKv6cUgwNYKgmEWk1OG8iKiDbDFDCmZAvP1z3EKMwyRdlN8QMyJhsPmw9z+wE97vDDpJFw42MVKzdKLIHRS3j2Wti3pRFoEBsTJ5u2pmu8U8/jsdbDroQkV+TNmSp5/4HkOpfmmvTDhhaWULG9LQRdA51Lj2P6UYUkyRdbZtTLXCvsc3QOFir2mg9L7CSYjgM0ffUoV++xwUzpt6FcW6fTSBHRB863Jfe3pKn81SS8NyeOSdBIgxnYPc30qZ69a6aQ/hfRyY1wrxtHWtXNokN3cdoXhRoXA2+2e9GEOzkPRgcptffTZJfKfB6xzm9zYGEcKU5SsyBK2Hc4ANsUabkjt12M2zf4KGetMfLhV/k8F/iwiV8xZLmkxGGm0XkejOvXuKqam75cBHITfyFTntVy0L9klFNTF42di3ZvPI+fc4QdFQRFoK0Gkp+jINnD5cKxq4lukFXyk8/Y8EmBTcmogfldN9t/owVEk7ourUnZux3W3Semau30H18SWoOs7hoobhwDdhyoYCqwNpLYs9GiuyDXoLoxkeuWqp8hHQms270pGBFNeLe4mUYZAY6FRp+xjuoRGyWZAzTTrXGn8geHaXdx1E/k8KgJ6YE5Eq7+Sx3Nc+QorMXSLJhIkB4etH4hja0F8nB8Jp2sT5fAvcT1rxKdwYlu75tRza8M="
+    # MATTERMOST_HOOK_URL for yarn cozyPublish script
+    - secure: dqNzH/ztrvk1JSuqG/5YU4GCBdaKjPIw0uPnYc4ln++h4mqmEjLakOqUeUNsiQrbw+usHt358T51SzzkDm8X1l85KcfdYekZlesEZB0x+pWY/d7ao+qp8VHlHjqHz6jwa9Xeio4xL9VTU49vRC8yxkvFFkoCX/4OmePZ3iNKqZXVbuXhtfn4eMf4ONMFc0gSeC+jhertvXySYnhsauA1XALpliL9X5M5aWDTbItpp3jIktc7zqYgv1IaAlYh/Jz62X8HleujvvgZYcwx62p8b/ZvAYjK9NcuCDY8JNpj/5G5h+R+H8M5fwEMkz4gzJEJes8Sx0wcp8twdenchOMcBHmiHWesFchYDI5kZfBe4Tz92oCwJ2kPM3/58suk3e41Y5r8Iz5Gyu0R1lR6jT+wgKaXfCVKkjeTUGtwItHTioAHahVp9ho0YV27fu1+F8uveJ2QEqsLut7Hby325kWoo3fo2p1bffxWIun9u9zp/jrzSfDH8EGRDisOMe969P4Ns+1gNkBpSsRQGkMa4+6CCSB8JR4p7LW0XpT3rwJLk1YBTtws9Ew+5mwvQSQVIWjuSGs6T6afp9fbaX7NnlAL6y820j7p4ra4yuvO5DxxAPxz6MfWNFmpuE4fI/qkNIUk1o8T+wSQGM5wSghhJie3Ptt0V5HUTFoPRwlVUVtV+1g=
 cache:
   yarn: true
   directories:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "@testing-library/react": "^9.4.0",
     "babel-preset-cozy-app": "1.7.0",
-    "cozy-app-publish": "^0.22.3",
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.15.1",
     "eslint-plugin-prettier": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "cs start --hot --browser",
     "deploy": "git-directory-deploy --directory build/ --branch ${DEPLOY_BRANCH:-build} --repo=${DEPLOY_REPOSITORY:-https://$GITHUB_TOKEN@github.com/cozy/cozy-passwords.git}",
     "test": "NODE_ENV=test cs test --verbose",
-    "cozyPublish": "cozy-app-publish --token $REGISTRY_TOKEN --prepublish downcloud --space default"
+    "cozyPublish": "cozy-app-publish --token $REGISTRY_TOKEN --prepublish downcloud --postpublish mattermost --space default"
   },
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@testing-library/react": "^9.4.0",
     "babel-preset-cozy-app": "1.7.0",
-    "cozy-app-publish": "0.22.1",
+    "cozy-app-publish": "^0.22.3",
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.15.1",
     "eslint-plugin-prettier": "3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3250,10 +3250,10 @@ cosmiconfig@^5.0.0:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-cozy-app-publish@0.22.1:
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/cozy-app-publish/-/cozy-app-publish-0.22.1.tgz#e0b67a0d0aca2489ec1777eb06089bac2418e79a"
-  integrity sha512-gZM34fSDFkdf85gBMz5EEangPG/dx6Y/CDfimWRehkluZNUK3igIAU/HlZdEll5o2xQm6B2pFXXz9tdk+JLCmg==
+cozy-app-publish@^0.22.3:
+  version "0.22.3"
+  resolved "https://registry.yarnpkg.com/cozy-app-publish/-/cozy-app-publish-0.22.3.tgz#4c45d1c3e2d36e4c00707633b1f68ea69b811725"
+  integrity sha512-zLxz0A/sbICa22Ti1Kp//v4zkZg3UIJoDrdfLYrZkFtTO+igL2Q4IqGUjCNCjjm3KsRcdk6aeh1i2fs6fmuZlw==
   dependencies:
     argparse "^1.0.10"
     chalk "2.4.2"
@@ -7852,13 +7852,6 @@ mini-css-extract-plugin@0.7.0:
 minilog@3.1.0, "minilog@https://github.com/cozy/minilog.git#master":
   version "3.1.0"
   resolved "https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
-  dependencies:
-    microee "0.0.6"
-
-"minilog@git+https://github.com/cozy/minilog.git#master":
-  version "3.1.0"
-  uid f01f7d9dfe20981177dd34b9662c2f077d818f82
-  resolved "git+https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
   dependencies:
     microee "0.0.6"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1870,7 +1870,7 @@ aproba@^1.1.1:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
-argparse@^1.0.10, argparse@^1.0.7:
+argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
@@ -3249,21 +3249,6 @@ cosmiconfig@^5.0.0:
     is-directory "^0.3.1"
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
-
-cozy-app-publish@^0.22.3:
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/cozy-app-publish/-/cozy-app-publish-0.22.3.tgz#4c45d1c3e2d36e4c00707633b1f68ea69b811725"
-  integrity sha512-zLxz0A/sbICa22Ti1Kp//v4zkZg3UIJoDrdfLYrZkFtTO+igL2Q4IqGUjCNCjjm3KsRcdk6aeh1i2fs6fmuZlw==
-  dependencies:
-    argparse "^1.0.10"
-    chalk "2.4.2"
-    cross-spawn "6.0.5"
-    fs-extra "7.0.1"
-    lodash "4.17.15"
-    node-fetch "2.6.0"
-    prompt "1.0.0"
-    request "2.88.0"
-    tar "4.4.13"
 
 cozy-bar@7.12.2:
   version "7.12.2"
@@ -5350,15 +5335,6 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-fs-extra@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
-  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs-extra@8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -5367,13 +5343,6 @@ fs-extra@8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
-
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
 
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
@@ -7882,21 +7851,6 @@ minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
-
 mississippi@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022"
@@ -7926,7 +7880,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x.x, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -8103,11 +8057,6 @@ node-fetch-npm@^2.0.2:
     encoding "^0.1.11"
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
-
-node-fetch@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -10387,7 +10336,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@2.88.0, request@^2.87.0, request@^2.88.0:
+request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -11530,19 +11479,6 @@ tapable@^1.0.0, tapable@^1.1.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar@4.4.13:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
-
 terser-webpack-plugin@^1.1.0:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz#5ecaf2dbdc5fb99745fd06791f46fc9ddb1c9a7c"
@@ -12638,7 +12574,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
Post message to mattermost after publication.

- Configured MATTERMOST_HOOK_URL
- Configured MATTERMOST_CHANNEL (publication channel only for beta/stable versions)
- Updated cozy-app-publish (on other repo it is automatically updated since it is
  installed at publish time, should we do the same here ?)