### PR TITLE
feat: Add safari as supported platform

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -4,7 +4,7 @@
   "slug": "passwords",
   "icon": "icon.svg",
   "categories": ["cozy"],
-  "version": "0.3.6",
+  "version": "0.3.7",
   "licence": "AGPL-3.0",
   "editor": "cozy",
   "source": "registry://passwords/stable",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-passwords",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "scripts": {
     "tx": "tx pull --all || true",
     "lint": "yarn lint:js && yarn lint:styles",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "watch:browser": "cs watch --browser",
     "watch:mobile": "cs watch --mobile",
     "start": "cs start --hot --browser",
-    "deploy": "git-directory-deploy --directory build/ --branch ${DEPLOY_BRANCH:-build} --repo=${DEPLOY_REPOSITORY:-https://$GITHUB_TOKEN@github.com/cozy/cozy-passwords.git}",
+    "deploy": "git-directory-deploy --directory build/ --branch ${DEPLOY_BRANCH:-build} --repo=${DEPLOY_REPOSITORY:-origin}",
     "test": "NODE_ENV=test cs test --verbose",
     "cozyPublish": "cozy-app-publish --token $REGISTRY_TOKEN --prepublish downcloud --postpublish mattermost --space default"
   },

--- a/src/components/AvailablePlatforms.jsx
+++ b/src/components/AvailablePlatforms.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react'
 import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
-import supportedPlatforms from 'supportedPlatforms'
+import getSupportedPlatforms from 'supportedPlatforms'
 import Stack from 'cozy-ui/transpiled/react/Stack'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { isAndroid, isIOS } from 'cozy-device-helper'
@@ -69,6 +69,7 @@ const storeLinksPerOS = {
 
 const AvailablePlatforms = props => {
   const { t } = useI18n()
+  const supportedPlatforms = getSupportedPlatforms()
   return (
     <Card {...props}>
       <Stack spacing="m">

--- a/src/components/InstallationPage/index.jsx
+++ b/src/components/InstallationPage/index.jsx
@@ -71,9 +71,13 @@ const DumbInstallationPage = props => {
               </Stack>
               <Card className="u-ta-left">
                 <OrderedList className="u-mv-0">
-                  <ListItem>
-                    {t(`InstallationPage.step1.${browser.name}`)}
-                  </ListItem>
+                  <ListItem
+                    dangerouslySetInnerHTML={{
+                      __html: snarkdown(
+                        t(`InstallationPage.step1.${browser.name}`)
+                      )
+                    }}
+                  />
                   <ListItem
                     dangerouslySetInnerHTML={{
                       __html: snarkdown(

--- a/src/components/InstallationPage/index.jsx
+++ b/src/components/InstallationPage/index.jsx
@@ -24,6 +24,8 @@ const DumbInstallationPage = props => {
   const { t } = useI18n()
   const cozyURL = new URL(client.getStackClient().uri)
 
+  const platform = supportedPlatforms[browser.name] || {}
+  const storeURL = platform.storeUrl
   const isNativeMobile = isMobile()
   return (
     <VerticallyCentered>
@@ -89,7 +91,7 @@ const DumbInstallationPage = props => {
                 </OrderedList>
               </Card>
               <ButtonLink
-                href={supportedPlatforms[browser.name].storeUrl}
+                href={storeURL}
                 target="_blank"
                 label={t('InstallationPage.cta')}
                 extension="full"

--- a/src/components/InstallationPage/index.jsx
+++ b/src/components/InstallationPage/index.jsx
@@ -12,7 +12,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { withClient } from 'cozy-client'
 import snarkdown from 'snarkdown'
 import WithCozyIcon from 'components/WithCozyIcon'
-import supportedPlatforms from 'supportedPlatforms'
+import getSupportedPlatforms from 'supportedPlatforms'
 import VerticallyCentered from '../VerticallyCentered'
 import { InstallNativeAppButton } from '../AvailablePlatforms'
 import { isMobile } from 'cozy-device-helper'
@@ -24,6 +24,7 @@ const DumbInstallationPage = props => {
   const { t } = useI18n()
   const cozyURL = new URL(client.getStackClient().uri)
 
+  const supportedPlatforms = getSupportedPlatforms()
   const platform = supportedPlatforms[browser.name] || {}
   const storeURL = platform.storeUrl
   const isNativeMobile = isMobile()

--- a/src/components/PresentationPage.jsx
+++ b/src/components/PresentationPage.jsx
@@ -15,7 +15,7 @@ import VerticallyCentered from './VerticallyCentered'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import Infos from 'cozy-ui/transpiled/react/Infos'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import supportedPlatforms from 'supportedPlatforms'
+import getSupportedPlatforms from 'supportedPlatforms'
 import { isSupportedBrowser, browserName } from 'currentBrowser'
 
 const Section1 = () => {
@@ -50,6 +50,7 @@ const Section3 = () => {
 
 const UnsupportedBrowser = () => {
   const { t } = useI18n()
+  const supportedPlatforms = getSupportedPlatforms()
   return (
     <Infos
       className="u-ta-left"
@@ -95,7 +96,6 @@ const UnsupportedBrowser = () => {
 const PresentationPage = () => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
-
   return (
     <VerticallyCentered>
       <Wrapper>
@@ -128,9 +128,9 @@ const PresentationPage = () => {
                   )}
                 </Grid>
               </Card>
-              {!isSupportedBrowser ? <UnsupportedBrowser /> : null}
+              {!isSupportedBrowser() ? <UnsupportedBrowser /> : null}
             </Stack>
-            {isSupportedBrowser ? (
+            {isSupportedBrowser() ? (
               <NarrowContent className="u-mh-auto">
                 <Button
                   to="/security"

--- a/src/components/PresentationPage.jsx
+++ b/src/components/PresentationPage.jsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import Button from 'cozy-ui/transpiled/react/Button'
+import cx from 'classnames'
+import Button, { ButtonLink } from 'cozy-ui/transpiled/react/Button'
 import Stack from 'cozy-ui/transpiled/react/Stack'
-import { MainTitle, Text } from 'cozy-ui/transpiled/react/Text'
+import { MainTitle, Text, SubTitle } from 'cozy-ui/transpiled/react/Text'
 import Card from 'cozy-ui/transpiled/react/Card'
 import Grid from 'cozy-ui/transpiled/react/MuiCozyTheme/Grid'
 import NarrowContent from 'cozy-ui/transpiled/react/NarrowContent'
@@ -12,6 +13,10 @@ import CircleIcon from 'components/CircleIcon'
 import Wrapper from 'components/Wrapper'
 import VerticallyCentered from './VerticallyCentered'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import Infos from 'cozy-ui/transpiled/react/Infos'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import supportedPlatforms from 'supportedPlatforms'
+import { isSupportedBrowser, browserName } from 'currentBrowser'
 
 const Section1 = () => {
   const { t } = useI18n()
@@ -40,6 +45,50 @@ const Section3 = () => {
       <CircleIcon icon="to-the-cloud" size={32} color="var(--slateGrey)" />
       <Text tag="p">{t('PresentationPage.item3')}</Text>
     </Stack>
+  )
+}
+
+const UnsupportedBrowser = () => {
+  const { t } = useI18n()
+  return (
+    <Infos
+      className="u-ta-left"
+      theme="danger"
+      description={
+        <>
+          <SubTitle className="u-pomegranate">
+            {t('PresentationPage.notSupportedInfos.title', {
+              browser: browserName
+            })}
+          </SubTitle>
+          <Text>
+            {t('PresentationPage.notSupportedInfos.description', {
+              browser: browserName
+            })}
+          </Text>
+        </>
+      }
+      action={Object.entries(supportedPlatforms).map(
+        ([platform, infos], index) => (
+          <ButtonLink
+            key={platform}
+            href={infos.storeUrl}
+            icon={
+              <Icon
+                icon={`browser-${platform}`}
+                size={16}
+                color="var(--slateGrey)"
+              />
+            }
+            theme="secondary"
+            label={infos.label}
+            className={cx({
+              'u-ml-0': index === 0
+            })}
+          />
+        )
+      )}
+    />
   )
 }
 
@@ -79,15 +128,18 @@ const PresentationPage = () => {
                   )}
                 </Grid>
               </Card>
+              {!isSupportedBrowser ? <UnsupportedBrowser /> : null}
             </Stack>
-            <NarrowContent className="u-mh-auto">
-              <Button
-                to="/security"
-                label={t('PresentationPage.cta')}
-                tag={Link}
-                extension="full"
-              />
-            </NarrowContent>
+            {isSupportedBrowser ? (
+              <NarrowContent className="u-mh-auto">
+                <Button
+                  to="/security"
+                  label={t('PresentationPage.cta')}
+                  tag={Link}
+                  extension="full"
+                />
+              </NarrowContent>
+            ) : null}
           </Stack>
         </Stack>
       </Wrapper>

--- a/src/currentBrowser.js
+++ b/src/currentBrowser.js
@@ -3,7 +3,7 @@ import capitalize from 'lodash/capitalize'
 import { isSupportedPlatform } from 'supportedPlatforms'
 
 export const currentBrowser = detectBrowser()
-export const isSupportedBrowser = isSupportedPlatform(currentBrowser.name)
+export const isSupportedBrowser = () => isSupportedPlatform(currentBrowser.name)
 
 const normalizedBrowserNames = {
   ios: 'iOS'

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -45,11 +45,13 @@
     "cozyExtension": "Cozy extension",
     "step1": {
       "chrome": "Click below to open the Chrome Web Store",
-      "firefox": "Click below to open Firefox Add-ons"
+      "firefox": "Click below to open Firefox Add-ons",
+      "safari": "Click below to open the Mac App Store then click on **Get**"
     },
     "step2": {
       "chrome": "Then click on **Add to Chrome**",
-      "firefox": "Then click on **Add to Firefox**"
+      "firefox": "Then click on **Add to Firefox**",
+      "safari": "Then open Safari preferences to activate the extension (Preferences > Extensions)"
     },
     "step3": "Log in with your address **%{address}** and your password!",
     "cta": "Install Cozy extension"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -45,11 +45,13 @@
     "cozyExtension": "l'extension Cozy",
     "step1": {
       "chrome": "Cliquez ci-dessous pour ouvrir le Chrome Web Store",
-      "firefox": "Cliquez ci-dessous pour ouvrir Firefox Add-ons"
+      "firefox": "Cliquez ci-dessous pour ouvrir Firefox Add-ons",
+      "safari": "Cliquez ci-dessous pour ouvrir le Mac App Store puis cliquez sur **Obtenir**"
     },
     "step2": {
       "chrome": "Cliquez ensuite sur **Ajouter à Chrome**",
-      "firefox": "Cliquez ensuite sur **Ajouter à Firefox**"
+      "firefox": "Cliquez ensuite sur **Ajouter à Firefox**",
+      "safari": "Ouvrez ensuite les préférences Safari pour activer l'extension (Préférences > Extensions)"
     },
     "step3": "Connectez-vous avec votre adresse **%{address}** et votre mot de passe !",
     "cta": "Installer l'extension Cozy"

--- a/src/supportedPlatforms.js
+++ b/src/supportedPlatforms.js
@@ -8,6 +8,10 @@ const supportedPlatforms = {
     label: 'Mozilla Firefox',
     storeUrl:
       'https://addons.mozilla.org/en-US/firefox/addon/cozy-personal-cloud'
+  },
+  safari: {
+    label: 'Safari',
+    storeUrl: 'macappstore://itunes.apple.com/app/id1504487449?mt=12'
   }
 }
 

--- a/src/supportedPlatforms.js
+++ b/src/supportedPlatforms.js
@@ -1,24 +1,34 @@
-const supportedPlatforms = {
-  chrome: {
-    label: 'Google Chrome',
-    storeUrl:
-      'https://chrome.google.com/webstore/detail/cozy-personal-cloud/jplochopoaajoochpoccajmgelpfbbic'
-  },
-  firefox: {
-    label: 'Mozilla Firefox',
-    storeUrl:
-      'https://addons.mozilla.org/en-US/firefox/addon/cozy-personal-cloud'
-  },
-  safari: {
-    label: 'Safari',
-    storeUrl: 'macappstore://itunes.apple.com/app/id1504487449?mt=12'
+import flag from 'cozy-flags'
+
+const getSupportedPlatforms = () => {
+  const platforms = {
+    chrome: {
+      label: 'Google Chrome',
+      storeUrl:
+        'https://chrome.google.com/webstore/detail/cozy-personal-cloud/jplochopoaajoochpoccajmgelpfbbic'
+    },
+    firefox: {
+      label: 'Mozilla Firefox',
+      storeUrl:
+        'https://addons.mozilla.org/en-US/firefox/addon/cozy-personal-cloud'
+    }
   }
+
+  if (flag('passwords.safari-supported')) {
+    platforms.safari = {
+      label: 'Safari',
+      storeUrl: 'macappstore://itunes.apple.com/app/id1504487449?mt=12'
+    }
+  }
+
+  return platforms
 }
 
 export const isSupportedPlatform = platformName => {
+  const supportedPlatforms = getSupportedPlatforms()
   const normalizedPlatformName = platformName.trim().toLowerCase()
 
   return Object.keys(supportedPlatforms).includes(normalizedPlatformName)
 }
 
-export default supportedPlatforms
+export default getSupportedPlatforms


### PR DESCRIPTION
- Link in available platforms card
- Link in "unsupported platforms" info
- Link in installation page to mac app store + instructions

The unsupported platforms part was removed in a former PR e3e159d442fb351da28dc9b656799eaa784aaf9b but it was important so I
reintroduced it here.