### PR TITLE
fix: Correctly check if vault is configured to show error on hint node

### DIFF
--- a/src/components/InstallationPage/index.jsx
+++ b/src/components/InstallationPage/index.jsx
@@ -63,11 +63,13 @@ const InstallationPage = function() {
   const { t } = useI18n()
 
   const bitwardenSettings = useContext(BitwardenSettingsContext)
+  const isVaultConfigured =
+    bitwardenSettings && bitwardenSettings.extension_installed
 
   const [activeStep, setActiveStep] = useState(
     params.step
       ? STEPS[params.step]
-      : bitwardenSettings && bitwardenSettings.extension_installed
+      : isVaultConfigured
       ? STEPS.configureExtension
       : STEPS.presentation
   )
@@ -97,7 +99,7 @@ const InstallationPage = function() {
           }
           const labelProps = {
             error:
-              index === STEPS.hint && bitwardenSettings && hasHint === false
+              index === STEPS.hint && isVaultConfigured && hasHint === false
           }
           return (
             <Step key={label} {...stepProps}>

--- a/src/components/InstallationPage/index.spec.jsx
+++ b/src/components/InstallationPage/index.spec.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import AppLike from '../../../test/lib/AppLike'
+import InstallationPage from '.'
+import { render, act } from '@testing-library/react'
+import { BitwardenSettingsContext } from '../../bitwarden-settings'
+import { isWarningStep } from './step-test-utils'
+
+describe('installation page', () => {
+  describe('hint warning', () => {
+    const setup = async ({ vaultConfigured }) => {
+      const bitwardenSettings = { extension_installed: vaultConfigured }
+      let rendered
+      await act(async () => {
+        rendered = render(
+          <BitwardenSettingsContext.Provider value={bitwardenSettings}>
+            <AppLike>
+              <InstallationPage />
+            </AppLike>
+          </BitwardenSettingsContext.Provider>
+        )
+      })
+      return rendered
+    }
+
+    it('should not be shown if the vault is not configured', async () => {
+      const { queryByText } = await setup({ vaultConfigured: false })
+      const node = queryByText('Leave hint')
+      expect(isWarningStep(node)).toBe(false)
+    })
+
+    it('should be shown if the vault is not configured', async () => {
+      const { queryByText } = await setup({ vaultConfigured: true })
+      const node = queryByText('Leave hint')
+      expect(isWarningStep(node)).toBe(true)
+    })
+  })
+})

--- a/src/components/InstallationPage/step-test-utils.jsx
+++ b/src/components/InstallationPage/step-test-utils.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import {
+  Stepper,
+  Step,
+  StepLabel,
+  StepButton
+} from 'cozy-ui/transpiled/react/Stepper'
+
+const renderSVGWarningIcon = () => {
+  const { getByRole } = render(
+    <Stepper>
+      <Step>
+        <StepButton>
+          <StepLabel error={true}>error</StepLabel>
+        </StepButton>
+      </Step>
+    </Stepper>
+  )
+  const button = getByRole('button')
+  const svg = button.querySelector('svg')
+  return svg
+}
+
+let warningSvg
+
+const findStepButtonFromLabelNode = node => {
+  return node.parentNode.parentNode.parentNode
+}
+
+const haveSameClassList = (node1, node2) => {
+  const cs1 = node1.classList.toString()
+  const cs2 = node2.classList.toString()
+  return cs1 === cs2
+}
+
+const isWarningStep = stepLabelNode => {
+  const stepButtonNode = findStepButtonFromLabelNode(stepLabelNode)
+  const icon = stepButtonNode.querySelector('svg')
+  return haveSameClassList(warningSvg, icon)
+}
+
+beforeEach(() => {
+  warningSvg = renderSVGWarningIcon()
+})
+
+export { isWarningStep }


### PR DESCRIPTION
The test utility is pretty complex but I could not find a way to do it otherwise.
There is no role or test id on the warning svg icon.
AMHA we should move this file to cozy-ui. See https://github.com/cozy/cozy-ui/pull/1442

```
import { isWarningStep } from 'cozy-ui/transpiled/react/Stepper/test'
```