### PR TITLE
fix: Add missing labels for Installation step 4 when using Edge

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -77,7 +77,7 @@
     },
     "step2": {
       "chrome": "Then click on **Add to Chrome**",
-      "edge-chromium": "Then click on **Add to Chrome**",
+      "edge-chromium": "Then click on **Add to Chrome**. You may have to click on the **Allow extensions from other stores** button first.",
       "firefox": "Then click on **Add to Firefox**",
       "safari": "Then open Safari preferences to activate the extension (Preferences > Extensions)"
     },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -71,11 +71,13 @@
     },
     "step1": {
       "chrome": "Click below to open the Chrome Web Store",
+      "edge-chromium": "Click below to open the Chrome Web Store",
       "firefox": "Click below to open Firefox Add-ons",
       "safari": "Click below to open the Mac App Store then click on **Get**"
     },
     "step2": {
       "chrome": "Then click on **Add to Chrome**",
+      "edge-chromium": "Then click on **Add to Chrome**",
       "firefox": "Then click on **Add to Firefox**",
       "safari": "Then open Safari preferences to activate the extension (Preferences > Extensions)"
     },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -69,7 +69,7 @@
     },
     "step2": {
       "chrome": "Cliquez ensuite sur **Ajouter à Chrome**",
-      "edge-chromium": "Cliquez ensuite sur **Ajouter à Chrome**",
+      "edge-chromium": "Cliquez ensuite sur **Ajouter à Chrome**. Si nécessaire, cliquez sur le bouton **Autoriser les extensions provenant d'autres magasins** au préalable.",
       "firefox": "Cliquez ensuite sur **Ajouter à Firefox**",
       "safari": "Ouvrez ensuite les préférences Safari pour activer l'extension (Préférences > Extensions)"
     },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -63,11 +63,13 @@
     "cozyExtension": "l'extension Cozy",
     "step1": {
       "chrome": "Cliquez ci-dessous pour ouvrir le Chrome Web Store",
+      "edge-chromium": "Cliquez ci-dessous pour ouvrir le Chrome Web Store",
       "firefox": "Cliquez ci-dessous pour ouvrir Firefox Add-ons",
       "safari": "Cliquez ci-dessous pour ouvrir le Mac App Store puis cliquez sur **Obtenir**"
     },
     "step2": {
       "chrome": "Cliquez ensuite sur **Ajouter à Chrome**",
+      "edge-chromium": "Cliquez ensuite sur **Ajouter à Chrome**",
       "firefox": "Cliquez ensuite sur **Ajouter à Firefox**",
       "safari": "Ouvrez ensuite les préférences Safari pour activer l'extension (Préférences > Extensions)"
     },


### PR DESCRIPTION
Labels translations were missing for the installation step 4.
![image](https://user-images.githubusercontent.com/1884255/120196695-6db12500-c220-11eb-8d73-273bd96ebf2a.png)



Cozy extension is not available on Edge's store so I used the same labels as for chrome.
![image](https://user-images.githubusercontent.com/1884255/120196826-976a4c00-c220-11eb-826c-ff4383acd705.png)

